### PR TITLE
Refactoring: separating hypr-dock and hypr-alttab into two entry points (./cmd)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,42 @@ PROJECT_CONFIG_DIR = configs
 EXECUTABLE_DOCK = hypr-dock
 EXECUTABLE_ALTTAB = hypr-alttab
 
+CMD_DOCK = ./cmd/hypr-dock/.
+CMD_ALTTAB = ./cmd/hypr-alttab/.
+
 RESET := \033[0m
 GREEN := \033[32m
 YELLOW := \033[33m
 
-build:
+warn:
 	@if [ ! -f "$(PROJECT_BIN_DIR)/$(EXECUTABLE_DOCK)" ]; then \
 		echo -e "$(YELLOW)The first build may take an extremely long time due to linking with gtk3...$(RESET)"; \
 	fi
-	go build -v -o $(PROJECT_BIN_DIR)/$(EXECUTABLE_DOCK) ./main/.
-	go build -v -o $(PROJECT_BIN_DIR)/$(EXECUTABLE_ALTTAB) ./main/.
+
+build-all:
+	$(MAKE) build-dock
+	$(MAKE) build-alttab
+
+build: build-all
+
+build-dock:
+	$(MAKE) warn
+	go build -v -o $(PROJECT_BIN_DIR)/$(EXECUTABLE_DOCK) $(CMD_DOCK)
+
+build-alttab:
+	$(MAKE) warn
+	go build -v -o $(PROJECT_BIN_DIR)/$(EXECUTABLE_ALTTAB) $(CMD_ALTTAB)
+
+
+update-dock:
+	-sudo killall $(EXECUTABLE_DOCK) 2>/dev/null || true
+	sudo cp $(PROJECT_BIN_DIR)/$(EXECUTABLE_DOCK) /usr/bin/
+	@echo -e "$(GREEN)hypr-dock update.$(RESET)"
+
+update-alttab:
+	-sudo killall $(EXECUTABLE_DOCK) 2>/dev/null || true
+	sudo cp $(PROJECT_BIN_DIR)/$(EXECUTABLE_DOCK) /usr/bin/
+	@echo -e "$(GREEN)hypr-alttab update.$(RESET)"
 
 install: install-all
 
@@ -25,11 +51,6 @@ install-dock:
 	mkdir -p $(LOCAL_CONFIG_DIR)
 	cp -r $(PROJECT_CONFIG_DIR)/* $(LOCAL_CONFIG_DIR)/
 	@echo -e "$(GREEN)hypr-dock installed.$(RESET)"
-
-update-dock:
-	-sudo killall $(EXECUTABLE_DOCK) 2>/dev/null || true
-	sudo cp $(PROJECT_BIN_DIR)/$(EXECUTABLE_DOCK) /usr/bin/
-	@echo -e "$(GREEN)hypr-dock update.$(RESET)"
 
 install-alttab:
 	-sudo killall $(EXECUTABLE_ALTTAB) 2>/dev/null || true

--- a/cmd/hypr-alttab/main.go
+++ b/cmd/hypr-alttab/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "hypr-dock/internal/switcher"
+
+func main() {
+	switcher.Run()
+}

--- a/cmd/hypr-dock/main.go
+++ b/cmd/hypr-dock/main.go
@@ -17,25 +17,9 @@ import (
 	"hypr-dock/internal/pkg/utils"
 	"hypr-dock/internal/settings"
 	"hypr-dock/internal/state"
-	"hypr-dock/internal/switcher"
 )
 
 func main() {
-	// Handle flags
-	args := os.Args[1:]
-
-	// Check if run as "hypr-alttab"
-	exe, _ := os.Executable()
-	if len(os.Args) > 0 && (os.Args[0] == "hypr-alttab" || contains(exe, "hypr-alttab")) {
-		switcher.Run()
-		return
-	}
-
-	if len(args) > 0 && args[0] == "--switcher" {
-		switcher.Run()
-		return
-	}
-
 	signals.Handler()
 
 	lockFilePath := fmt.Sprintf("%s/hypr-dock-%s.lock", utils.TempDir(), os.Getenv("USER"))
@@ -87,17 +71,4 @@ func main() {
 
 	// end
 	gtk.Main()
-}
-
-func contains(s, substr string) bool {
-	for i := 0; i < len(s); i++ {
-		if hasPrefix(s[i:], substr) {
-			return true
-		}
-	}
-	return false
-}
-
-func hasPrefix(s, prefix string) bool {
-	return len(s) >= len(prefix) && s[0:len(prefix)] == prefix
 }


### PR DESCRIPTION
1. Separation of the project into two entry points (./cmd/hypr-dock and ./cmd/hypr-alttab)
2. The Makefile has been updated to account for the new cmd directory structure
3. The update target has been restored in the Makefile
4. Added the ability to compile the executables separately