### PR TITLE
Refactor layering and window control into a stateful OOP module

### DIFF
--- a/cmd/hypr-dock/main.go
+++ b/cmd/hypr-dock/main.go
@@ -53,7 +53,8 @@ func main() {
 
 	window.SetTitle("hypr-dock")
 
-	layering.SetWindowProperty(appState)
+	layerctl := layering.NewInit(window, settings)
+	appState.SetLayerctl(layerctl)
 
 	err = utils.AddCssProvider(settings.CurrentThemeStylePath)
 	if err != nil {

--- a/configs/config.jsonc
+++ b/configs/config.jsonc
@@ -4,8 +4,14 @@
     // Icon size (px) (default 23)
     "IconSize": 23,
 
-    // Window overlay layer height (auto, exclusive-top, exclusive-bottom, background, bottom, top, overlay) (default "auto")
-    "Layer": "exclusive-bottom",
+    // Window overlay layer height (background, bottom, top, overlay) (default "top")
+    "Layer": "top",
+
+    // Exclusive Zone (true, false) (default "true")
+    "Exclusive": "true",
+
+    // SmartView (true, false) (default "false")
+    "SmartView": "false",
 
     // Window position on screen (top, bottom, left, right) (default "bottom")
     "Position": "bottom",

--- a/configs/themes/lotos/lotos.jsonc
+++ b/configs/themes/lotos/lotos.jsonc
@@ -1,7 +1,4 @@
 {
-    // Blur window ("true", "false") (default "on")
-    "Blur": "true",
-
     // Distance between elements (px) (default 9)
     "Spacing": 5,
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -18,7 +18,7 @@ import (
 
 func BuildApp(appState *state.State) *gtk.Box {
 	settings := appState.GetSettings()
-	orientation := appState.GetOrientation()
+	orientation := appState.GetLayerctl().GetOrientation()
 
 	app, err := gtk.BoxNew(orientation, 0)
 	if err != nil {

--- a/internal/btnctl/btnctl.go
+++ b/internal/btnctl/btnctl.go
@@ -3,7 +3,6 @@ package btnctl
 import (
 	defaultcontrol "hypr-dock/internal/defaultControl"
 	"hypr-dock/internal/item"
-	"hypr-dock/internal/layering"
 	"hypr-dock/internal/pkg/utils"
 	"hypr-dock/internal/state"
 	"hypr-dock/pkg/ipc"
@@ -95,14 +94,14 @@ func previewControl(item *item.Item, ctrl *defaultcontrol.Control, appState *sta
 
 	// send to host control signal for auto mode
 	pv.OnEnter(func(w *gtk.Window, e *gdk.Event) {
-		appState.GetDockHideTimer().Stop()
+		appState.GetLayerctl().SendFocus()
 	})
 
 	pv.OnLeave(func(w *gtk.Window, e *gdk.Event) {
-		layering.DispathLeaveEvent(appState.GetWindow(), nil, appState)
+		appState.GetLayerctl().SendUnfocus()
 	})
 
 	pv.OnEmpty(func() {
-		layering.DispathLeaveEvent(appState.GetWindow(), nil, appState)
+		appState.GetLayerctl().SendUnfocus()
 	})
 }

--- a/internal/defaultControl/utils.go
+++ b/internal/defaultControl/utils.go
@@ -1,7 +1,6 @@
 package defaultcontrol
 
 import (
-	"hypr-dock/internal/layering"
 	"hypr-dock/internal/state"
 
 	"github.com/gotk3/gotk3/gdk"
@@ -18,10 +17,9 @@ func leftClick(btn *gtk.Button, handler func(e *gdk.Event)) {
 }
 
 func dispather(appState *state.State, btn *gtk.Button) {
-	window := appState.GetWindow()
 	btn.SetStateFlags(gtk.STATE_FLAG_NORMAL, true)
 	if appState.GetSettings().Layer == "auto" {
-		layering.DispathLeaveEvent(window, nil, appState)
+		appState.GetLayerctl().SendFocus()
 	}
 }
 

--- a/internal/detectZone/detectZone.go
+++ b/internal/detectZone/detectZone.go
@@ -1,7 +1,7 @@
 package detectzone
 
 import (
-	"hypr-dock/internal/state"
+	"hypr-dock/internal/settings"
 	"log"
 
 	"github.com/dlasky/gotk3-layershell/layershell"
@@ -9,45 +9,64 @@ import (
 	"github.com/gotk3/gotk3/gtk"
 )
 
-func Init(appState *state.State) {
-	window := appState.GetWindow()
+type DetectArea struct {
+	onEnter func()
+	onLeave func()
 
-	detectArea, err := gtk.WindowNew(gtk.WINDOW_TOPLEVEL)
+	*gtk.Window
+}
+
+func New(mainWindow *gtk.Window, settings settings.Settings) *DetectArea {
+	detectWindow, err := gtk.WindowNew(gtk.WINDOW_TOPLEVEL)
 	if err != nil {
 		log.Fatal("InitDetectArea(), gtk.WindowNew() | ", err)
 	}
-	detectArea.SetName("detect")
-	detectArea.SetSizeRequest(-1, 1)
 
-	layershell.InitForWindow(detectArea)
-	layershell.SetNamespace(detectArea, "dock-detect")
-	layershell.SetLayer(detectArea, layershell.LAYER_SHELL_LAYER_TOP)
-	selectEdges(detectArea, appState)
+	da := &DetectArea{
+		Window: detectWindow,
+		onEnter: func() {
+			log.Printf("Detect enter")
+		},
+		onLeave: func() {
+			log.Printf("Detect leave")
+		},
+	}
 
-	detectArea.Connect("enter-notify-event", func(detectWindow *gtk.Window, e *gdk.Event) {
-		timer := appState.GetDockHideTimer()
-		timer.Stop()
+	da.SetName("detect")
+	da.SetSizeRequest(-1, 1)
 
-		go func() {
-			layershell.SetLayer(window, layershell.LAYER_SHELL_LAYER_TOP)
-		}()
-	})
+	layershell.InitForWindow(da.Window)
+	layershell.SetNamespace(da.Window, "dock-detect")
+	layershell.SetLayer(da.Window, layershell.LAYER_SHELL_LAYER_TOP)
 
-	detectArea.Connect("leave-notify-event", func(detectWindow *gtk.Window, e *gdk.Event) {
-		timer := appState.GetDockHideTimer()
+	da.clickes()
 
-		timer.Run(appState.Settings.AutoHideDelay, func() {
-			layershell.SetLayer(window, layershell.LAYER_SHELL_LAYER_BOTTOM)
-		})
-	})
+	selectEdges(da.Window, settings)
 
-	detectArea.ShowAll()
-	appState.SetDetectArea(detectArea)
+	da.ShowAll()
+
+	return da
 }
 
-func selectEdges(window *gtk.Window, appState *state.State) {
-	settings := appState.GetSettings()
+func (da *DetectArea) clickes() {
+	da.Connect("enter-notify-event", func(detectWindow *gtk.Window, e *gdk.Event) {
+		da.onEnter()
+	})
 
+	da.Connect("leave-notify-event", func(detectWindow *gtk.Window, e *gdk.Event) {
+		da.onLeave()
+	})
+}
+
+func (da *DetectArea) OnEnter(handler func()) {
+	da.onEnter = handler
+}
+
+func (da *DetectArea) OnLeave(handler func()) {
+	da.onLeave = handler
+}
+
+func selectEdges(window *gtk.Window, settings settings.Settings) {
 	switch settings.Position {
 	case "left":
 		layershell.SetAnchor(window, layershell.LAYER_SHELL_EDGE_BOTTOM, true)

--- a/internal/hypr/hyprEvents/events.go
+++ b/internal/hypr/hyprEvents/events.go
@@ -44,10 +44,10 @@ func activatespecialHandler(event string, appState *state.State) {
 
 	if data[0] == "special:special" {
 		log.Println("Special workspace activated")
-		appState.SetSpecial(true)
+		appState.GetLayerctl().SetSpecial(true)
 	} else {
 		log.Println("Special workspace deactivated")
-		appState.SetSpecial(false)
+		appState.GetLayerctl().SetSpecial(false)
 	}
 }
 
@@ -83,4 +83,3 @@ func eventHandler(event string, n int) []string {
 
 	return dataParts
 }
-

--- a/internal/layering/layering.go
+++ b/internal/layering/layering.go
@@ -2,31 +2,33 @@ package layering
 
 import (
 	detectzone "hypr-dock/internal/detectZone"
-	"hypr-dock/internal/state"
-	"strings"
+	"hypr-dock/internal/pkg/timer"
+	"hypr-dock/internal/settings"
 
 	"github.com/dlasky/gotk3-layershell/layershell"
 	"github.com/gotk3/gotk3/gdk"
+	"github.com/gotk3/gotk3/glib"
 	"github.com/gotk3/gotk3/gtk"
 )
 
-func SetWindowProperty(appState *state.State) {
-	window := appState.GetWindow()
-	settings := appState.GetSettings()
+type Control struct {
+	window   *gtk.Window
+	settings settings.Settings
+	da       *detectzone.DetectArea
 
-	layershell.InitForWindow(window)
-	layershell.SetNamespace(window, "hypr-dock")
+	smartEnter glib.SignalHandle
+	smartLeave glib.SignalHandle
 
-	ChangePosition(settings.Position, appState)
-	ChangeLayer(settings.Layer, appState)
+	hideTimer *timer.Timer
+	special   bool
+
+	orientation gtk.Orientation
+	edge        layershell.LayerShellEdgeFlags
+
+	layers map[string]layershell.LayerShellLayerFlags
 }
 
-func ChangeLayer(layer string, appState *state.State) {
-	window := appState.GetWindow()
-	if window == nil {
-		return
-	}
-
+func New(window *gtk.Window, settings settings.Settings) *Control {
 	layers := map[string]layershell.LayerShellLayerFlags{
 		"background": layershell.LAYER_SHELL_LAYER_BACKGROUND,
 		"bottom":     layershell.LAYER_SHELL_LAYER_BOTTOM,
@@ -34,31 +36,45 @@ func ChangeLayer(layer string, appState *state.State) {
 		"overlay":    layershell.LAYER_SHELL_LAYER_OVERLAY,
 	}
 
-	if layer == "auto" {
-		layershell.SetLayer(window, layers["bottom"])
-		layershell.SetExclusiveZone(window, 0)
-		AutoLayer(appState)
-		detectzone.Init(appState)
-		return
-	}
+	return &Control{
+		window:   window,
+		settings: settings,
 
-	DisableAutoLayer(appState)
-	if strings.Contains(layer, "exclusive") {
-		exLayer := strings.Split(layer, "-")[1]
-		layershell.SetLayer(window, layers[exLayer])
-		layershell.AutoExclusiveZoneEnable(window)
-		return
+		layers:    layers,
+		hideTimer: timer.New(),
 	}
-
-	layershell.SetLayer(window, layers[layer])
 }
 
-func ChangePosition(position string, appState *state.State) {
-	window := appState.GetWindow()
-	if window == nil {
+func (c *Control) Init() {
+	layershell.InitForWindow(c.window)
+	layershell.SetNamespace(c.window, "hypr-dock")
+
+	c.SetPosition()
+	c.SetLayer()
+}
+
+func NewInit(window *gtk.Window, settings settings.Settings) *Control {
+	ctrl := New(window, settings)
+	ctrl.Init()
+	return ctrl
+}
+
+func (c *Control) SetLayer() {
+	c.clear()
+
+	if c.settings.SmartView == "true" {
+		c.smart()
 		return
 	}
 
+	if c.settings.Exclusive == "true" {
+		layershell.AutoExclusiveZoneEnable(c.window)
+	}
+
+	layershell.SetLayer(c.window, c.layers[c.settings.Layer])
+}
+
+func (c *Control) SetPosition() {
 	oreintations := map[string]gtk.Orientation{
 		"bottom": gtk.ORIENTATION_HORIZONTAL,
 		"top":    gtk.ORIENTATION_HORIZONTAL,
@@ -73,65 +89,96 @@ func ChangePosition(position string, appState *state.State) {
 		"right":  layershell.LAYER_SHELL_EDGE_RIGHT,
 	}
 
-	layershell.SetAnchor(window, edges[position], true)
-	layershell.SetMargin(window, edges[position], 0)
+	position := c.settings.Position
 
-	appState.SetOrientation(oreintations[position])
-	appState.SetEdge(edges[position])
+	layershell.SetAnchor(c.window, edges[position], true)
+	layershell.SetMargin(c.window, edges[position], 0)
+
+	c.orientation = oreintations[position]
+	c.edge = edges[position]
 }
 
-func AutoLayer(appState *state.State) {
-	DisableAutoLayer(appState)
-	window := appState.GetWindow()
+func (c *Control) smart() {
+	layershell.SetLayer(c.window, c.layers["bottom"])
 
-	enterSig := window.Connect("enter-notify-event", func(window *gtk.Window, e *gdk.Event) {
-		event := gdk.EventCrossingNewFromEvent(e)
-		isInWindow := event.Detail() == 3 || event.Detail() == 4
+	c.da = detectzone.New(c.window, c.settings)
+	c.da.OnEnter(func() {
+		c.SendFocus()
+	})
+	c.da.OnLeave(func() {
+		c.SendUnfocus()
+	})
 
-		if !isInWindow || appState.GetSpecial() {
+	c.smartEnter = c.window.Connect("enter-notify-event", func(_ *gtk.Window, e *gdk.Event) {
+		if !is_e3e4(e) || c.special {
 			return
 		}
 
-		timer := appState.GetDockHideTimer()
-
-		timer.Stop()
-		layershell.SetLayer(window, layershell.LAYER_SHELL_LAYER_TOP)
+		c.SendFocus()
 	})
-	appState.AddSignalHandler("enter", enterSig)
 
-	leaveSig := window.Connect("leave-notify-event", func(window *gtk.Window, e *gdk.Event) {
-		DispathLeaveEvent(window, e, appState)
+	c.smartLeave = c.window.Connect("leave-notify-event", func(_ *gtk.Window, e *gdk.Event) {
+		if !is_e3e4(e) {
+			return
+		}
+
+		c.SendUnfocus()
 	})
-	appState.AddSignalHandler("leave", leaveSig)
 }
 
-func DispathLeaveEvent(window *gtk.Window, e *gdk.Event, appState *state.State) {
-	isInWindow := true
-	if e != nil {
-		event := gdk.EventCrossingNewFromEvent(e)
-		isInWindow = event.Detail() == 3 || event.Detail() == 4
+func (c *Control) clear() {
+	layershell.SetExclusiveZone(c.window, 0)
+
+	if c.da != nil {
+		c.da.Destroy()
+		c.da = nil
 	}
 
-	if !isInWindow {
+	if c.smartEnter > 0 {
+		c.window.HandlerDisconnect(c.smartEnter)
+	}
+
+	if c.smartLeave > 0 {
+		c.window.HandlerDisconnect(c.smartLeave)
+	}
+}
+
+func (c *Control) SendUnfocus() {
+	if c.settings.SmartView != "true" {
 		return
 	}
 
-	timer := appState.GetDockHideTimer()
-
-	timer.Run(appState.Settings.AutoHideDelay, func() {
-		layershell.SetLayer(window, layershell.LAYER_SHELL_LAYER_BOTTOM)
+	c.hideTimer.Run(c.settings.AutoHideDelay, func() {
+		layershell.SetLayer(c.window, layershell.LAYER_SHELL_LAYER_BOTTOM)
 	})
 }
 
-func DisableAutoLayer(appState *state.State) {
-	detectArea := appState.GetDetectArea()
-	if detectArea != nil {
-		detectArea.Destroy()
-		appState.SetDetectArea(nil)
+func (c *Control) SendFocus() {
+	if c.settings.SmartView != "true" {
+		return
 	}
 
-	window := appState.GetWindow()
+	c.hideTimer.Stop()
+	layershell.SetLayer(c.window, c.layers["top"])
+}
 
-	appState.RemoveSignalHandler("enter", window)
-	appState.RemoveSignalHandler("leave", window)
+func (c *Control) SetSpecial(is bool) {
+	c.special = is
+}
+
+func (c *Control) GetSpecial() bool {
+	return c.special
+}
+
+func (c *Control) GetOrientation() gtk.Orientation {
+	return c.orientation
+}
+
+func (c *Control) GetEdge() layershell.LayerShellEdgeFlags {
+	return c.edge
+}
+
+func is_e3e4(e *gdk.Event) bool {
+	ec := gdk.EventCrossingNewFromEvent(e)
+	return ec.Detail() == 3 || ec.Detail() == 4
 }

--- a/internal/pkg/cfg/cfg.go
+++ b/internal/pkg/cfg/cfg.go
@@ -15,8 +15,9 @@ type Config struct {
 	CurrentTheme    string
 	IconSize        int
 	Layer           string
+	Exclusive       string
+	SmartView       string
 	Position        string
-	Blur            string
 	Spacing         int
 	AutoHideDelay   int
 	SystemGapUsed   string
@@ -55,9 +56,10 @@ func GetDefaultConfig() Config {
 	return Config{
 		CurrentTheme:  "lotos",
 		IconSize:      21,
-		Layer:         "auto",
+		Layer:         "top",
+		Exclusive:     "true",
+		SmartView:     "false",
 		Position:      "bottom",
-		Blur:          "true",
 		Spacing:       8,
 		SystemGapUsed: "true",
 		AutoHideDelay: 400,
@@ -106,15 +108,22 @@ func ReadConfig(jsoncFile string, themesDir string) Config {
 	}
 
 	if !validate.Layer(config.Layer, false) {
+		ValidWarn("Layer", config.Layer, GetDefaultConfig().Layer, jsoncFile)
 		config.Layer = GetDefaultConfig().Layer
+	}
+
+	if !validate.Boolen(config.Exclusive) {
+		ValidWarn("Exclusive", config.Exclusive, GetDefaultConfig().Exclusive, jsoncFile)
+		config.Exclusive = GetDefaultConfig().Exclusive
+	}
+
+	if !validate.Boolen(config.SmartView) {
+		ValidWarn("SmartView", config.SmartView, GetDefaultConfig().SmartView, jsoncFile)
+		config.SmartView = GetDefaultConfig().SmartView
 	}
 
 	if !validate.Position(config.Position, false) {
 		config.Position = GetDefaultConfig().Position
-	}
-
-	if !validate.Blur(config.Blur, false) {
-		config.Blur = GetDefaultConfig().Blur
 	}
 
 	if !validate.SystemGapUsed(config.SystemGapUsed, false) {
@@ -155,10 +164,6 @@ func ReadTheme(jsoncFile string, config Config) *ThemeConfig {
 	}
 
 	// Set default values ​​if not specified
-	if !validate.Blur(config.Blur, false) {
-		themeConfig.Blur = config.Blur
-	}
-
 	if themeConfig.Spacing < 0 {
 		themeConfig.Spacing = config.Spacing
 	}
@@ -260,4 +265,9 @@ func WriteItemList(jsonFile string, data ItemList) error {
 	}
 
 	return nil
+}
+
+func ValidWarn(key string, value string, defaultVal, file string) {
+	log.Printf("ERROR: config value \"%s\":\"%s\" is not valid in file: %s", key, value, file)
+	log.Printf("DEBUG: default value \"%s\":\"%s\" is used", key, defaultVal)
 }

--- a/internal/pkg/validate/validate.go
+++ b/internal/pkg/validate/validate.go
@@ -11,7 +11,7 @@ func Preview(value string, runtime bool) bool {
 }
 
 func Layer(value string, runtime bool) bool {
-	validList := []string{"auto", "exclusive-top", "exclusive-bottom", "background", "bottom", "top", "overlay"}
+	validList := []string{"background", "bottom", "top", "overlay"}
 	return Allowed("Layer", value, validList, runtime, true)
 }
 
@@ -20,14 +20,14 @@ func Position(value string, runtime bool) bool {
 	return Allowed("Position", value, validList, runtime, true)
 }
 
-func Blur(value string, runtime bool) bool {
-	validList := []string{"true", "false"}
-	return Allowed("Blur", value, validList, runtime, false)
-}
-
 func SystemGapUsed(value string, runtime bool) bool {
 	validList := []string{"true", "false"}
 	return Allowed("SystemGapUsed", value, validList, runtime, true)
+}
+
+func Boolen(value string) bool {
+	validList := []string{"true", "false"}
+	return Allowed("SystemGapUsed", value, validList, false, false)
 }
 
 func Allowed[T comparable](key string, value T, validList []T, runtime bool, logs bool) bool {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -4,7 +4,6 @@ import (
 	"hypr-dock/internal/pkg/cfg"
 	"hypr-dock/internal/pkg/flags"
 	"hypr-dock/internal/pkg/utils"
-	"hypr-dock/pkg/ipc"
 	"log"
 	"os"
 	"path/filepath"
@@ -66,16 +65,8 @@ func Init() (Settings, error) {
 
 	themeConfig := cfg.ReadTheme(settings.CurrentThemeConfigPath, settings.Config)
 	if themeConfig != nil {
-		settings.Blur = themeConfig.Blur
 		settings.Spacing = themeConfig.Spacing
 		settings.PreviewStyle = themeConfig.PreviewStyle
-	}
-
-	if settings.Blur == "true" {
-		enableBlur()
-		ipc.AddEventListener("configreloaded", func(event string) {
-			go enableBlur()
-		}, true)
 	}
 
 	return settings, nil
@@ -111,12 +102,4 @@ func expandPath(path string) string {
 		return filepath.Join(home, path[2:])
 	}
 	return path
-}
-
-func enableBlur() {
-	ipc.Hyprctl("keyword layerrule blur,hypr-dock")
-	ipc.Hyprctl("keyword layerrule ignorealpha 0.1,hypr-dock")
-
-	ipc.Hyprctl("keyword layerrule blur,dock-popup")
-	ipc.Hyprctl("keyword layerrule ignorealpha 0.1,dock-popup")
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2,103 +2,69 @@ package state
 
 import (
 	"hypr-dock/internal/itemsctl"
-	"hypr-dock/internal/pkg/timer"
+	"hypr-dock/internal/layering"
 	"hypr-dock/internal/pvctl"
 	"hypr-dock/internal/settings"
 	"sync"
 
-	"github.com/dlasky/gotk3-layershell/layershell"
-	"github.com/gotk3/gotk3/glib"
 	"github.com/gotk3/gotk3/gtk"
 )
 
 type State struct {
-	Settings       settings.Settings
-	Window         *gtk.Window
-	SignalHandlers map[string]glib.SignalHandle
-	DetectArea     *gtk.Window
-	ItemsBox       *gtk.Box
-	Orientation    gtk.Orientation
-	Edge           layershell.LayerShellEdgeFlags
-	DockHideTimer  *timer.Timer
-	List           *itemsctl.List
-	Special        bool
-	PV             *pvctl.PV
-	ContextOpen    bool
-	mu             sync.Mutex
+	settings settings.Settings
+	window   *gtk.Window
+	layerctl *layering.Control
+	itemsBox *gtk.Box
+	list     *itemsctl.List
+	pv       *pvctl.PV
+	mu       sync.Mutex
 }
 
 func New(settings settings.Settings) *State {
 	return &State{
-		Settings:      settings,
-		DockHideTimer: timer.New(),
-		List:          itemsctl.New(),
-		PV:            pvctl.New(settings),
+		settings: settings,
+		list:     itemsctl.New(),
+		pv:       pvctl.New(settings),
 	}
+}
+
+func (s *State) SetLayerctl(ctl *layering.Control) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.layerctl = ctl
+}
+
+func (s *State) GetLayerctl() *layering.Control {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.layerctl
 }
 
 func (s *State) GetList() *itemsctl.List {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.List
-}
-
-func (s *State) GetDockHideTimer() *timer.Timer {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return s.DockHideTimer
-}
-
-func (s *State) AddSignalHandler(name string, id glib.SignalHandle) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.SignalHandlers == nil {
-		s.SignalHandlers = make(map[string]glib.SignalHandle)
-	}
-	s.SignalHandlers[name] = id
-}
-
-func (s *State) RemoveSignalHandler(name string, window *gtk.Window) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if id, exists := s.SignalHandlers[name]; exists {
-		window.HandlerDisconnect(id)
-		delete(s.SignalHandlers, name)
-	}
-}
-
-func (s *State) SetEdge(edge layershell.LayerShellEdgeFlags) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.Edge = edge
-}
-
-func (s *State) GetEdge() layershell.LayerShellEdgeFlags {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.Edge
+	return s.list
 }
 
 func (s *State) SetSettings(settings settings.Settings) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.Settings = settings
+	s.settings = settings
 }
 
 func (s *State) GetSettings() settings.Settings {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.Settings
+	return s.settings
 }
 
 func (s *State) GetPinned() *[]string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return &s.Settings.PinnedApps
+	return &s.settings.PinnedApps
 }
 
 func (s *State) Update(fn func(*State)) {
@@ -110,80 +76,30 @@ func (s *State) Update(fn func(*State)) {
 func (s *State) SetWindow(window *gtk.Window) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.Window = window
-}
-
-func (s *State) SetDetectArea(window *gtk.Window) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.DetectArea = window
+	s.window = window
 }
 
 func (s *State) SetItemsBox(box *gtk.Box) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.ItemsBox = box
-}
-
-func (s *State) SetOrientation(orientation gtk.Orientation) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.Orientation = orientation
-}
-
-func (s *State) SetSpecial(is bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.Special = is
+	s.itemsBox = box
 }
 
 func (s *State) GetWindow() *gtk.Window {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.Window
-}
-
-func (s *State) GetDetectArea() *gtk.Window {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.DetectArea
+	return s.window
 }
 
 func (s *State) GetItemsBox() *gtk.Box {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.ItemsBox
-}
-
-func (s *State) GetOrientation() gtk.Orientation {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.Orientation
-}
-
-func (s *State) GetSpecial() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.Special
+	return s.itemsBox
 }
 
 func (s *State) GetPV() *pvctl.PV {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.PV
-}
-
-func (s *State) GetContextOpen() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return s.ContextOpen
-}
-
-func (s *State) SetContextOpen(flag bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.ContextOpen = flag
+	return s.pv
 }


### PR DESCRIPTION
Refactor layering and window control into a stateful OOP module, replacing legacy auto-hide logic with configurable SmartView and adding exclusive zone control

1. Rewrote layering system as OOP class (layering.Control) with state management
2. Replaced deprecated "auto" layer with new "SmartView" and "Exclusive" config options
3. Decoupled layering logic from app state - created independent controller
4. Enhanced detection zone as separate OOP class (detectzone.DetectArea)
5. Removed legacy blur support (https://github.com/lotos-linux/hypr-dock/issues/25)
6. Improved configuration validation with better error messages
7. Fixed signal handling to prevent memory leaks and race conditions