### PR TITLE
Fix frame capture timeout by actively dispatching Wayland events

### DIFF
--- a/pkg/wl/app.go
+++ b/pkg/wl/app.go
@@ -201,17 +201,25 @@ OUTER:
 		return nil, err
 	}
 
-	if err := a.roundTrip(); err != nil {
-		return nil, err
+	// Actively dispatch events while waiting for the frame to be ready.
+	// The compositor sends the ready event asynchronously after copying
+	// the frame data, so we must keep dispatching to receive it.
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case <-ready:
+			goto frameReady
+		case err := <-failed:
+			return nil, err
+		case <-timeout:
+			return nil, fmt.Errorf("timeout waiting for frame ready")
+		default:
+			if err := a.display.Context().Dispatch(); err != nil {
+				return nil, fmt.Errorf("dispatch error while waiting for frame: %w", err)
+			}
+		}
 	}
-
-	select {
-	case <-ready:
-	case err := <-failed:
-		return nil, err
-	case <-time.After(500 * time.Millisecond):
-		return nil, fmt.Errorf("timeout waiting for frame ready")
-	}
+frameReady:
 
 	data := pool.Data()
 	img := image.NewNRGBA(image.Rect(0, 0, int(selected.Width), int(selected.Height)))


### PR DESCRIPTION
## Summary
Fixes #34

The live/static preview feature consistently fails with `timeout waiting for frame ready` because Wayland events are not being dispatched after `frame.Copy()` is called.

## Problem
In `pkg/wl/app.go`, `CaptureFrame()` calls `frame.Copy()` then does a single `roundTrip()` followed by a passive `select` waiting on the `ready` channel. The compositor sends the ready event asynchronously after it finishes copying the frame data, but since `roundTrip()` has already returned, no code is calling `Dispatch()` on the Wayland context. The ready event sits unread in the socket until the 500ms timeout fires.

## Fix
Replace the `roundTrip()` + passive wait with an active dispatch loop that continuously calls `Dispatch()` while checking for the ready signal, the failed signal, or a timeout (increased to 2s to accommodate complex windows).

```go
// Before (broken):
if err := a.roundTrip(); err != nil { ... }
select {
case <-ready:
case <-time.After(500 * time.Millisecond):
    return nil, fmt.Errorf("timeout waiting for frame ready")
}

// After (fixed):
timeout := time.After(2 * time.Second)
for {
    select {
    case <-ready:
        goto frameReady
    case err := <-failed:
        return nil, err
    case <-timeout:
        return nil, fmt.Errorf("timeout waiting for frame ready")
    default:
        if err := a.display.Context().Dispatch(); err != nil {
            return nil, fmt.Errorf("dispatch error while waiting for frame: %w", err)
        }
    }
}
```

Tested with both `live` and `static` preview modes on Hyprland 0.54.0.