### PR TITLE
fix(search): fall back to StartupWMClass when filename heuristics fail

### DIFF
--- a/internal/desktop/search.go
+++ b/internal/desktop/search.go
@@ -1,6 +1,7 @@
 package desktop
 
 import (
+	"hypr-dock/pkg/ini"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,6 +71,42 @@ func SearchDesktopFile(className string) string {
 	path, exist := GetFiles()[className]
 	if exist {
 		return path
+	}
+
+	// Fallback: match by StartupWMClass field inside .desktop files
+	// Handles cases where the filename doesn't match the WM_CLASS,
+	// e.g. "beeper.desktop" with StartupWMClass=BeeperTexts
+	return searchByStartupWMClass(className)
+}
+
+func searchByStartupWMClass(className string) string {
+	for _, appDir := range GetAppDirs() {
+		files, err := os.ReadDir(appDir)
+		if err != nil {
+			continue
+		}
+
+		for _, file := range files {
+			if file.IsDir() || !strings.HasSuffix(file.Name(), ".desktop") {
+				continue
+			}
+
+			filePath := filepath.Join(appDir, file.Name())
+			raw, err := ini.GetMap(filePath, "Desktop Entry")
+			if err != nil {
+				continue
+			}
+
+			general, exist := raw["Desktop Entry"]
+			if !exist {
+				continue
+			}
+
+			wmClass, exist := general["StartupWMClass"]
+			if exist && wmClass == className {
+				return filePath
+			}
+		}
 	}
 
 	return ""


### PR DESCRIPTION
## Summary

- Adds a `StartupWMClass` fallback to `SearchDesktopFile` that scans `.desktop` files when all filename-based heuristics fail to find a match
- Uses the existing `ini.GetMap` parser to read the `StartupWMClass` field and match it against the window's WM_CLASS
- Only runs as a last resort after all existing filename matching strategies are exhausted, so there is no performance impact for apps that already match

Fixes #37

## Problem

Apps whose `.desktop` filename doesn't correlate with their WM_CLASS get no icon in the dock. For example, Beeper installs as `beeper.desktop` but reports `WM_CLASS=BeeperTexts`. The [XDG Desktop Entry spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/) defines `StartupWMClass` for exactly this association, but hypr-dock wasn't reading it.

## Testing

Built and tested locally on Arch Linux + Hyprland. Verified with Beeper (`beeper.desktop`, `StartupWMClass=BeeperTexts`) which previously showed a missing icon in the dock. After the fix, the icon resolves correctly via the `StartupWMClass` fallback without any filename workarounds (e.g. symlinks in `~/.local/share/hypr-dock/applications/`).